### PR TITLE
Update Dockerfile.arm32v7

### DIFF
--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -16,7 +16,8 @@ RUN apt-get update && \
     apt-get install -y unzip \
         libudev-dev libusb-0.1-4 \
         curl libcurl4 libcurl4-gnutls-dev \
-        libpython3.7-dev
+        libpython3.7-dev \
+        tzdata
 
 COPY domoticz/ /opt/domoticz/
 WORKDIR /opt/domoticz


### PR DESCRIPTION
Allow timezones to be mounted via volume (/etc/localtime:/etc/localtime:ro)